### PR TITLE
Delete errant 'NoColor'

### DIFF
--- a/color.go
+++ b/color.go
@@ -163,10 +163,6 @@ func (c *Color) unsetWriter(w io.Writer) {
 		return
 	}
 
-	if NoColor {
-		return
-	}
-
 	fmt.Fprintf(w, "%s[%dm", escape, Reset)
 }
 


### PR DESCRIPTION
Accessing that global overrode intentional enabling/disabling of color
output elsewhere.